### PR TITLE
Automatic updating function for chat messages

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -66,3 +66,15 @@ $(function(){
       })
   });
 });
+  let reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    let last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -91,3 +91,7 @@ $(function(){
         $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
       }
     })
+    .fail(function() {
+      alert('error');
+    });
+  };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       let html =
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
         <div class="message__upper-info">
           <p class="message__upper-info__name">
             ${message.user_nickname}
@@ -22,7 +22,7 @@ $(function(){
       return html;
     } else {
       let html =
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
         <div class="message__upper-info">
           <p class="message__upper-info__name">
             ${message.user_nickname}

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -95,3 +95,8 @@ $(function(){
       alert('error');
     });
   };
+
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -78,3 +78,16 @@ $(function(){
       //dataオプションでリクエストに値を含める
       data: {id: last_message_id}
     })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        //追加するHTMLの入れ物を作る
+        let insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.main-chat__message-list').append(insertHTML);
+        $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
+      }
+    })

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも大きいもののみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.text
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_nickname message.user.nickname
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__upper-info
     %p.message__upper-info__name
       = message.user.nickname

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_nickname @message.user.nickname
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.text @message.text
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   root "groups#index"
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
-    resources :messages, only: [:index,:create]
+    resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
### What
- 同グループ内の別ユーザーにもメッセージの自動更新を適用する
- 別ユーザーの画面上においてもメッセージ最下部に自動的にスクロールするようにする

### Why
- リロードをせずに他ユーザーからの最新メッセージを随時取得し、チャットとして機能させる為
- 自動スクロールさせることで最新メッセージを読みやすくする為

### Gifのリンクはこちらです。
https://gyazo.com/e7941bd3a1e03eadb850e0a230269505